### PR TITLE
Make clippy pedantic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "firefly-rust"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "nalgebra",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-rust"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Firefly Zero team"]
 description = "Rust SDK for making Firefly Zero games"

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -26,5 +26,5 @@ extern fn update() {
     let image = unsafe { IMAGE.get().unwrap() };
     let image: ff::Image = (image).into();
     let colors = ff::ImageColors::default();
-    ff::draw_image(image, ff::Point { x: 60, y: 60 }, colors);
+    ff::draw_image(&image, ff::Point { x: 60, y: 60 }, &colors);
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,9 +8,9 @@ use alloc::vec::Vec;
 
 /// Like [File] but owns the buffer.
 ///
-/// Returned by [rom::load_buf] and [data::load_buf]. Requires a global allocator.
-/// For a file of statically-known size, you might want to use [rom::load]
-/// and [data::load] instead.
+/// Returned by [`rom::load_buf`] and [`data::load_buf`]. Requires a global allocator.
+/// For a file of statically-known size, you might want to use [`rom::load`]
+/// and [`data::load`] instead.
 #[cfg(feature = "alloc")]
 pub struct FileBuf {
     pub(crate) raw: Vec<u8>,
@@ -39,9 +39,9 @@ impl FileBuf {
 
 /// A file loaded from ROM or data dir into the memory.
 ///
-/// Returned by [rom::load] and [data::load] which requires a pre-allocated buffer
+/// Returned by [`rom::load`] and [`data::load`] which requires a pre-allocated buffer
 /// of the right size. If the file size is deterimed dynamically,
-/// you might want to use [rom::load_buf] and [data::load_buf] instead
+/// you might want to use [`rom::load_buf`] and [`data::load_buf`] instead
 /// (which will take care of the dynamic allocation).
 pub struct File<'a> {
     pub(crate) raw: &'a [u8],
@@ -82,7 +82,7 @@ pub mod rom {
     /// Read the whole file with the given name into the given buffer.
     ///
     /// If the file size is not known in advance (and so the buffer has to be allocated
-    /// dynamically), consider using [load_buf] instead.
+    /// dynamically), consider using [`load_buf`] instead.
     pub fn load<'a>(name: &str, buf: &'a mut [u8]) -> File<'a> {
         let path_ptr = name.as_ptr();
         let buf_ptr = buf.as_mut_ptr();
@@ -128,7 +128,7 @@ pub mod data {
     /// Read the whole file with the given name into the given buffer.
     ///
     /// If the file size is not known in advance (and so the buffer has to be allocated
-    /// dynamically), consider using [load_buf] instead.
+    /// dynamically), consider using [`load_buf`] instead.
     pub fn load<'a>(name: &str, buf: &'a mut [u8]) -> File<'a> {
         let path_ptr = name.as_ptr();
         let buf_ptr = buf.as_mut_ptr();
@@ -183,7 +183,7 @@ pub mod data {
 
 /// A loaded font file.
 ///
-/// Can be loaded as [FileBuf] from ROM with [rom::load_buf]
+/// Can be loaded as [`FileBuf`] from ROM with [`rom::load_buf`]
 /// and then cast using [Into].
 pub struct Font<'a> {
     pub(crate) raw: &'a [u8],
@@ -204,7 +204,7 @@ impl<'a> From<&'a FileBuf> for Font<'a> {
 
 /// A loaded image file.
 ///
-/// Can be loaded as [FileBuf] from ROM with [rom::load_buf]
+/// Can be loaded as [`FileBuf`] from ROM with [`rom::load_buf`]
 /// and then cast using [Into].
 pub struct Image<'a> {
     pub(crate) raw: &'a [u8],
@@ -235,7 +235,7 @@ impl<'a> Image<'a> {
     }
 }
 
-/// A subregion of an image. Constructed using [Image::sub].
+/// A subregion of an image. Constructed using [`Image::sub`].
 pub struct SubImage<'a> {
     pub(crate) point: Point,
     pub(crate) size:  Size,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -19,16 +19,19 @@ pub struct FileBuf {
 #[cfg(feature = "alloc")]
 impl FileBuf {
     /// Access the raw data in the file.
+    #[must_use]
     pub fn data(&self) -> &[u8] {
         &self.raw
     }
 
     /// Interpret the file as a font.
+    #[must_use]
     pub fn as_font(&self) -> Font {
         Font { raw: &self.raw }
     }
 
     /// Interpret the file as an image.
+    #[must_use]
     pub fn as_image(&self) -> Image {
         Image { raw: &self.raw }
     }
@@ -45,14 +48,17 @@ pub struct File<'a> {
 }
 
 impl<'a> File<'a> {
+    #[must_use]
     pub fn data(&self) -> &[u8] {
         self.raw
     }
 
+    #[must_use]
     pub fn as_font(&self) -> Font {
         Font { raw: self.raw }
     }
 
+    #[must_use]
     pub fn as_image(&self) -> Image {
         Image { raw: self.raw }
     }
@@ -95,6 +101,7 @@ pub mod rom {
     ///
     /// If you have a pre-allocated buffer of the right size, use [load] instead.
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn load_buf(name: &str) -> FileBuf {
         let size = rom::get_size(name);
         let mut buf = vec![0; size];
@@ -140,6 +147,7 @@ pub mod data {
     ///
     /// If you have a pre-allocated buffer of the right size, use [load] instead.
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn load_buf(name: &str) -> FileBuf {
         let size = data::get_size(name);
         let mut buf = vec![0; size];
@@ -217,6 +225,7 @@ impl<'a> From<&'a FileBuf> for Image<'a> {
 
 impl<'a> Image<'a> {
     /// Get a rectangle subregion of the image.
+    #[must_use]
     pub fn sub(&self, p: Point, s: Size) -> SubImage<'a> {
         SubImage {
             point: p,

--- a/src/graphics/angle.rs
+++ b/src/graphics/angle.rs
@@ -4,7 +4,7 @@ use core::ops::*;
 
 /// An angle between two vectors.
 ///
-/// Used by [draw_arc] and [draw_sector].
+/// Used by [`draw_arc`] and [`draw_sector`].
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
 pub struct Angle(pub(crate) f32);
 

--- a/src/graphics/angle.rs
+++ b/src/graphics/angle.rs
@@ -19,46 +19,55 @@ impl Angle {
     pub const ZERO: Angle = Angle(0.);
 
     /// An angle in degrees where 360.0 is the full circle.
+    #[must_use]
     pub fn from_degrees(d: f32) -> Self {
         Self(d * PI / 180.0)
     }
 
     /// An angle in radians where [TAU] (doubled [PI]) is the full circle.
+    #[must_use]
     pub fn from_radians(r: f32) -> Self {
         Self(r)
     }
 
     /// Convert the angle to an absolute (non-negative) value.
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(math::abs(self.0))
     }
 
     /// Normalize the angle to less than one full rotation (in the range 0°..360°).
+    #[must_use]
     pub fn normalize(self) -> Self {
-        Self(math::rem_euclid(self.0, 2.0 * PI))
+        Self(math::rem_euclid(self.0, TAU))
     }
 
     /// Get the angle value in degrees where 360.0 is the full circle..
+    #[must_use]
     pub fn to_degrees(self) -> f32 {
         180. * self.0 / PI
     }
 
     /// Get the angle value in radians where [TAU] (doubled [PI]) is the full circle.
+    #[must_use]
     pub fn to_radians(self) -> f32 {
         self.0
     }
 
     /// Approximates `sin(x)` of the angle with a maximum error of `0.002`.
+    #[must_use]
     pub fn sin(&self) -> f32 {
         math::sin(self.0)
     }
 
     /// Approximates `cos(x)` of the angle with a maximum error of `0.002`.
+    #[must_use]
     pub fn cos(&self) -> f32 {
         math::cos(self.0)
     }
 
     /// Approximates `tan(x)` of the angle with a maximum error of `0.6`.
+    #[must_use]
     pub fn tan(&self) -> f32 {
         math::tan(self.0)
     }

--- a/src/graphics/angle.rs
+++ b/src/graphics/angle.rs
@@ -140,6 +140,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_to_degrees() {
         let a = Angle::from_degrees;
         assert_eq!(a(47.).to_degrees(), 47.);

--- a/src/graphics/bindings.rs
+++ b/src/graphics/bindings.rs
@@ -94,17 +94,17 @@ extern {
         stroke_width: i32,
     );
     pub(crate) fn draw_text(
-        text_ptr: i32,
-        text_len: i32,
-        font_ptr: i32,
-        font_len: i32,
+        text_ptr: u32,
+        text_len: u32,
+        font_ptr: u32,
+        font_len: u32,
         x: i32,
         y: i32,
         color: i32,
     );
     pub(crate) fn draw_sub_image(
-        ptr: i32,
-        len: i32,
+        ptr: u32,
+        len: u32,
         x: i32,
         y: i32,
         sub_x: i32,
@@ -117,8 +117,8 @@ extern {
         c4: i32,
     );
     pub(crate) fn draw_image(
-        ptr: i32,
-        len: i32,
+        ptr: u32,
+        len: u32,
         x: i32,
         y: i32,
         c1: i32,

--- a/src/graphics/funcs.rs
+++ b/src/graphics/funcs.rs
@@ -31,7 +31,7 @@ pub fn set_colors(dark: RGB, accent: RGB, secondary: RGB, light: RGB) {
             light.r.into(),
             light.g.into(),
             light.b.into(),
-        )
+        );
     }
 }
 
@@ -172,10 +172,10 @@ pub fn draw_text(t: &str, f: &Font, p: Point, c: Color) {
     let font_len = f.raw.len();
     unsafe {
         b::draw_text(
-            text_ptr as i32,
-            text_len as i32,
-            font_ptr as i32,
-            font_len as i32,
+            text_ptr as u32,
+            text_len as u32,
+            font_ptr as u32,
+            font_len as u32,
             p.x,
             p.y,
             c.into(),
@@ -184,13 +184,13 @@ pub fn draw_text(t: &str, f: &Font, p: Point, c: Color) {
 }
 
 /// Render an image using the given colors.
-pub fn draw_image(i: Image, p: Point, c: ImageColors) {
+pub fn draw_image(i: &Image, p: Point, c: &ImageColors) {
     let ptr = i.raw.as_ptr();
     let len = i.raw.len();
     unsafe {
         b::draw_image(
-            ptr as i32,
-            len as i32,
+            ptr as u32,
+            len as u32,
             p.x,
             p.y,
             c.a.into(),
@@ -204,13 +204,13 @@ pub fn draw_image(i: Image, p: Point, c: ImageColors) {
 /// Draw a subregion of an image.
 ///
 /// Most often used to draw a sprite from a sprite atlas.
-pub fn draw_sub_image(i: SubImage, p: Point, c: ImageColors) {
+pub fn draw_sub_image(i: &SubImage, p: Point, c: &ImageColors) {
     let ptr = i.raw.as_ptr();
     let len = i.raw.len();
     unsafe {
         b::draw_sub_image(
-            ptr as i32,
-            len as i32,
+            ptr as u32,
+            len as u32,
             p.x,
             p.y,
             i.point.x,

--- a/src/graphics/point.rs
+++ b/src/graphics/point.rs
@@ -23,6 +23,7 @@ impl Point {
     pub const MIN: Point = Point { x: 0, y: 0 };
 
     /// Set x and y to their absolute (non-negative) value.
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -31,6 +32,7 @@ impl Point {
     }
 
     /// Set both x and y to their minimum in the two given points.
+    #[must_use]
     pub fn component_min(self, other: Self) -> Self {
         Self {
             x: self.x.min(other.x),
@@ -39,6 +41,7 @@ impl Point {
     }
 
     /// Set both x and y to their maximum in the two given points.
+    #[must_use]
     pub fn component_max(self, other: Self) -> Self {
         Self {
             x: self.x.max(other.x),

--- a/src/graphics/size.rs
+++ b/src/graphics/size.rs
@@ -26,7 +26,8 @@ impl Size {
     };
 
     /// Set both width and height to their absolute (non-negative) value.
-    pub fn abs(&self) -> Self {
+    #[must_use]
+    pub fn abs(self) -> Self {
         Self {
             width:  self.width.abs(),
             height: self.height.abs(),
@@ -34,6 +35,7 @@ impl Size {
     }
 
     /// Set both width and height to their minimum in the two given points.
+    #[must_use]
     pub fn component_min(self, other: Self) -> Self {
         Self {
             width:  self.width.min(other.width),
@@ -42,6 +44,7 @@ impl Size {
     }
 
     /// Set both width and height to their maximum in the two given points.
+    #[must_use]
     pub fn component_max(self, other: Self) -> Self {
         Self {
             width:  self.width.max(other.width),

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -34,7 +34,7 @@ impl Default for Style {
 impl Style {
     /// Convert the style to a line style.
     ///
-    /// [LineStyle] is the same as [Style] except it doesn't have a fill color.
+    /// [`LineStyle`] is the same as [Style] except it doesn't have a fill color.
     #[must_use]
     pub fn as_line_style(&self) -> LineStyle {
         LineStyle {

--- a/src/input.rs
+++ b/src/input.rs
@@ -84,7 +84,7 @@ impl From<Size> for Pad {
 
 /// DPad-like representation of the [Pad].
 ///
-/// Constructed with [Pad::as_dpad]. Useful for simple games and ports.
+/// Constructed with [`Pad::as_dpad`]. Useful for simple games and ports.
 /// The middle of the pad is a "dead zone" pressing which will not activate any direction.
 ///
 /// Invariant: it's not possible for opposite directions (left and right, or down and up)

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,6 +19,7 @@ impl Pad {
     pub const MIN: Pad = Pad { x: -1000, y: -1000 };
 
     /// Represent the pad values as a directional pad.
+    #[must_use]
     pub fn as_dpad(&self) -> DPad {
         DPad {
             left:  self.x <= -DPAD_THRESHOLD,
@@ -29,6 +30,7 @@ impl Pad {
     }
 
     /// The distance from the pad center to the touch point.
+    #[must_use]
     pub fn radius(self) -> f32 {
         let r = self.x * self.x + self.y * self.y;
         math::sqrt(r as f32)
@@ -37,6 +39,7 @@ impl Pad {
     /// The angle of the [polar coordinate] of the touch point.
     ///
     /// [polar coordinate]: https://en.wikipedia.org/wiki/Polar_coordinate_system
+    #[must_use]
     pub fn azimuth(self) -> Angle {
         let r = math::atan(self.y as f32 / self.x as f32);
         Angle::from_radians(r)
@@ -103,6 +106,7 @@ impl From<Pad> for DPad {
 
 impl DPad {
     /// Given the old state, get directions that were not pressed but are pressed now.
+    #[must_use]
     pub fn just_pressed(&self, old: &Self) -> Self {
         Self {
             left:  self.left && !old.left,
@@ -113,6 +117,7 @@ impl DPad {
     }
 
     /// Given the old state, get directions that were pressed but aren't pressed now.
+    #[must_use]
     pub fn just_released(&self, old: &Self) -> Self {
         Self {
             left:  !self.left && old.left,
@@ -123,6 +128,7 @@ impl DPad {
     }
 
     /// Given the old state, get directions that were pressed but are still pressed now.
+    #[must_use]
     pub fn held(&self, old: &Self) -> Self {
         Self {
             left:  self.left && old.left,
@@ -152,11 +158,13 @@ pub struct Buttons {
 
 impl Buttons {
     /// Check if any button is pressed.
+    #[must_use]
     pub fn any(&self) -> bool {
         self.a || self.b || self.x || self.y || self.menu
     }
 
     /// Given the old state, get buttons that were not pressed but are pressed now.
+    #[must_use]
     pub fn just_pressed(&self, old: &Self) -> Self {
         Self {
             a:    self.a && !old.a,
@@ -168,6 +176,7 @@ impl Buttons {
     }
 
     /// Given the old state, get buttons that were pressed but aren't pressed now.
+    #[must_use]
     pub fn just_released(&self, old: &Self) -> Self {
         Self {
             a:    !self.a && old.a,
@@ -179,6 +188,7 @@ impl Buttons {
     }
 
     /// Given the old state, get buttons that were pressed but are still pressed now.
+    #[must_use]
     pub fn held(&self, old: &Self) -> Self {
         Self {
             a:    self.a && old.a,

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,6 +33,7 @@ impl Pad {
     #[must_use]
     pub fn radius(self) -> f32 {
         let r = self.x * self.x + self.y * self.y;
+        #[allow(clippy::cast_precision_loss)]
         math::sqrt(r as f32)
     }
 
@@ -41,6 +42,7 @@ impl Pad {
     /// [polar coordinate]: https://en.wikipedia.org/wiki/Polar_coordinate_system
     #[must_use]
     pub fn azimuth(self) -> Angle {
+        #[allow(clippy::cast_precision_loss)]
         let r = math::atan(self.y as f32 / self.x as f32);
         Angle::from_radians(r)
     }
@@ -210,8 +212,8 @@ pub fn read_pad(player: Player) -> Option<Pad> {
         None
     } else {
         Some(Pad {
-            x: (raw >> 16) as i16 as i32,
-            y: raw as i16 as i32,
+            x: i32::from((raw >> 16) as i16),
+            y: i32::from(raw as i16),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // #![warn(clippy::pedantic)]
 #![warn(clippy::must_use_candidate)]
+#![warn(clippy::doc_markdown)]
+#![allow(clippy::wildcard_imports)]
 #![allow(clippy::cast_possible_truncation)]
 
 mod bindings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::struct_excessive_bools)]
 #![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::enum_glob_use)]
 #![allow(clippy::iter_without_into_iter)]
 
 mod bindings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+// #![warn(clippy::pedantic)]
+#![warn(clippy::must_use_candidate)]
+#![allow(clippy::cast_possible_truncation)]
 
 mod bindings;
 mod fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-// #![warn(clippy::pedantic)]
-#![warn(clippy::must_use_candidate)]
-#![warn(clippy::doc_markdown)]
+#![deny(clippy::pedantic)]
 #![allow(clippy::wildcard_imports)]
+#![allow(clippy::struct_excessive_bools)]
 #![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::enum_glob_use)]
+#![allow(clippy::iter_without_into_iter)]
 
 mod bindings;
 mod fs;

--- a/src/math.rs
+++ b/src/math.rs
@@ -37,6 +37,7 @@ pub fn cos(x: f32) -> f32 {
 #[must_use]
 pub fn floor(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/floor.rs
+    #[allow(clippy::cast_precision_loss)]
     let mut res = (x as i32) as f32;
     if x < res {
         res -= 1.0;
@@ -109,6 +110,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_sqrt() {
         assert_eq!(sqrt(4.), 2.);
         assert_eq!(sqrt(9.), 3.125);

--- a/src/math.rs
+++ b/src/math.rs
@@ -10,16 +10,19 @@ use core::f32::consts::{FRAC_1_PI, FRAC_PI_2, PI};
 const SIGN_MASK: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
 
 /// Approximates `tan(x)` in radians with a maximum error of `0.6`.
+#[must_use]
 pub fn tan(x: f32) -> f32 {
     sin(x) / cos(x)
 }
 
 /// Approximates `sin(x)` in radians with a maximum error of `0.002`.
+#[must_use]
 pub fn sin(x: f32) -> f32 {
     cos(x - PI / 2.0)
 }
 
 /// Approximates `cos(x)` in radians with a maximum error of `0.002`.
+#[must_use]
 pub fn cos(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/cos.rs
     let mut x = x;
@@ -31,6 +34,7 @@ pub fn cos(x: f32) -> f32 {
 }
 
 /// Returns the largest integer less than or equal to a number.
+#[must_use]
 pub fn floor(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/floor.rs
     let mut res = (x as i32) as f32;
@@ -41,12 +45,14 @@ pub fn floor(x: f32) -> f32 {
 }
 
 /// Returns the absolute value of a number.
+#[must_use]
 pub fn abs(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/abs.rs
     f32::from_bits(x.to_bits() & !SIGN_MASK)
 }
 
 /// Approximates the square root of a number with an average deviation of ~5%.
+#[must_use]
 pub fn sqrt(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/sqrt.rs
     if x >= 0. {
@@ -57,6 +63,7 @@ pub fn sqrt(x: f32) -> f32 {
 }
 
 // Calculates the least nonnegative remainder of lhs (mod rhs).
+#[must_use]
 pub fn rem_euclid(lhs: f32, rhs: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/rem_euclid.rs
     let r = lhs % rhs;
@@ -71,6 +78,7 @@ pub fn rem_euclid(lhs: f32, rhs: f32) -> f32 {
 /// `0.002`.
 ///
 /// Returns [`f32::NAN`] if the number is [`f32::NAN`].
+#[must_use]
 pub fn atan(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/atan.rs
     FRAC_PI_2 * atan_norm(x)
@@ -78,6 +86,7 @@ pub fn atan(x: f32) -> f32 {
 
 /// Approximates `atan(x)` normalized to the `[−1,1]` range with a maximum
 /// error of `0.1620` degrees.
+#[must_use]
 pub fn atan_norm(x: f32) -> f32 {
     // https://github.com/tarcieri/micromath/blob/main/src/float/atan.rs
     const SIGN_MASK: u32 = 0x8000_0000;
@@ -93,4 +102,15 @@ pub fn atan_norm(x: f32) -> f32 {
 
     // Restore the sign bit and convert to float
     f32::from_bits(ux_s | atan_1q.to_bits())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sqrt() {
+        assert_eq!(sqrt(4.), 2.);
+        assert_eq!(sqrt(9.), 3.125);
+    }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -26,6 +26,7 @@ pub fn set_seed(seed: u32) {
 }
 
 /// Get a random value.
+#[must_use]
 pub fn get_random() -> u32 {
     unsafe { b::get_random() }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -12,14 +12,14 @@ impl Player {
     #[inline]
     #[must_use]
     pub fn all() -> [Player; 4] {
-        use Player::*;
+        use Player::{P0, P1, P2, P3};
         [P0, P1, P2, P3]
     }
 
     /// Get all players except this one.
     #[must_use]
     pub fn others(&self) -> [Player; 3] {
-        use Player::*;
+        use Player::{P0, P1, P2, P3};
         match self {
             P0 => [P1, P2, P3],
             P1 => [P0, P2, P3],

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,12 +10,14 @@ pub enum Player {
 impl Player {
     /// Get all players.
     #[inline]
+    #[must_use]
     pub fn all() -> [Player; 4] {
         use Player::*;
         [P0, P1, P2, P3]
     }
 
     /// Get all players except this one.
+    #[must_use]
     pub fn others(&self) -> [Player; 3] {
         use Player::*;
         match self {

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -9,7 +9,7 @@ pub trait Shape {
     fn draw(&self);
 }
 
-/// A wrapper for [draw_line].
+/// A wrapper for [`draw_line`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Line {
     pub a:     Point,
@@ -23,7 +23,7 @@ impl Shape for Line {
     }
 }
 
-/// A wrapper for [draw_rect].
+/// A wrapper for [`draw_rect`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Rect {
     pub point: Point,
@@ -47,7 +47,7 @@ impl From<RoundedRect> for Rect {
     }
 }
 
-/// A wrapper for [draw_rounded_rect].
+/// A wrapper for [`draw_rounded_rect`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RoundedRect {
     pub point:  Point,
@@ -76,7 +76,7 @@ impl From<Rect> for RoundedRect {
     }
 }
 
-/// A wrapper for [draw_circle].
+/// A wrapper for [`draw_circle`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Circle {
     pub point:    Point,
@@ -90,7 +90,7 @@ impl Shape for Circle {
     }
 }
 
-/// A wrapper for [draw_ellipse].
+/// A wrapper for [`draw_ellipse`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Ellipse {
     pub point: Point,
@@ -117,7 +117,7 @@ impl From<Circle> for Ellipse {
     }
 }
 
-/// A wrapper for [draw_triangle].
+/// A wrapper for [`draw_triangle`].
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Triangle {
     pub a:     Point,
@@ -132,7 +132,7 @@ impl Shape for Triangle {
     }
 }
 
-/// A wrapper for [draw_arc].
+/// A wrapper for [`draw_arc`].
 #[derive(Clone, Debug)]
 pub struct Arc {
     pub point:    Point,
@@ -166,7 +166,7 @@ impl From<Sector> for Arc {
     }
 }
 
-/// A wrapper for [draw_sector].
+/// A wrapper for [`draw_sector`].
 #[derive(Clone, Debug)]
 pub struct Sector {
     pub point:    Point,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -19,7 +19,7 @@ pub struct Line {
 
 impl Shape for Line {
     fn draw(&self) {
-        draw_line(self.a, self.b, self.style)
+        draw_line(self.a, self.b, self.style);
     }
 }
 
@@ -33,7 +33,7 @@ pub struct Rect {
 
 impl Shape for Rect {
     fn draw(&self) {
-        draw_rect(self.point, self.size, self.style)
+        draw_rect(self.point, self.size, self.style);
     }
 }
 
@@ -58,7 +58,7 @@ pub struct RoundedRect {
 
 impl Shape for RoundedRect {
     fn draw(&self) {
-        draw_rounded_rect(self.point, self.size, self.corner, self.style)
+        draw_rounded_rect(self.point, self.size, self.corner, self.style);
     }
 }
 
@@ -86,7 +86,7 @@ pub struct Circle {
 
 impl Shape for Circle {
     fn draw(&self) {
-        draw_circle(self.point, self.diameter, self.style)
+        draw_circle(self.point, self.diameter, self.style);
     }
 }
 
@@ -100,7 +100,7 @@ pub struct Ellipse {
 
 impl Shape for Ellipse {
     fn draw(&self) {
-        draw_ellipse(self.point, self.size, self.style)
+        draw_ellipse(self.point, self.size, self.style);
     }
 }
 
@@ -128,7 +128,7 @@ pub struct Triangle {
 
 impl Shape for Triangle {
     fn draw(&self) {
-        draw_triangle(self.a, self.b, self.c, self.style)
+        draw_triangle(self.a, self.b, self.c, self.style);
     }
 }
 
@@ -150,7 +150,7 @@ impl Shape for Arc {
             self.start,
             self.sweep,
             self.style,
-        )
+        );
     }
 }
 
@@ -184,7 +184,7 @@ impl Shape for Sector {
             self.start,
             self.sweep,
             self.style,
-        )
+        );
     }
 }
 

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -72,7 +72,7 @@ impl<'a> Iterator for DirIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let len = self.raw.first()?;
         let len = *len as usize;
-        let raw_name = self.raw.get(1..(len + 1))?;
+        let raw_name = self.raw.get(1..=len)?;
         // Security: do NOT return None on invalid string. Otherwise,
         // adding an invalid name into the directory would hide all files
         // that go after that.

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -14,6 +14,7 @@ pub struct DirBuf {
 #[cfg(feature = "alloc")]
 impl DirBuf {
     /// List all subdirectories in the given directory.
+    #[must_use]
     pub fn list_dirs(name: &str) -> Self {
         let size = Dir::list_dirs_buf_size(name);
         let mut buf = vec![0; size];
@@ -22,6 +23,7 @@ impl DirBuf {
     }
 
     /// Iterate over all loaded entries in the directory.
+    #[must_use]
     pub fn iter(&self) -> DirIter<'_> {
         DirIter { raw: &self.raw }
     }
@@ -32,6 +34,7 @@ pub struct Dir<'a> {
 }
 
 impl<'a> Dir<'a> {
+    #[must_use]
     pub fn list_dirs_buf_size(name: &str) -> usize {
         let path_ptr = name.as_ptr();
         let size = unsafe { b::list_dirs_buf_size(path_ptr as u32, name.len() as u32) };
@@ -53,6 +56,7 @@ impl<'a> Dir<'a> {
     }
 
     /// Iterate over all loaded entries in the directory.
+    #[must_use]
     pub fn iter(&self) -> DirIter<'a> {
         DirIter { raw: self.raw }
     }
@@ -112,6 +116,7 @@ pub fn load_file<'a>(path: &str, buf: &'a mut [u8]) -> File<'a> {
 }
 
 #[cfg(feature = "alloc")]
+#[must_use]
 pub fn load_file_buf(path: &str) -> FileBuf {
     let size = get_file_size(path);
     let mut buf = vec![0; size];


### PR DESCRIPTION
1. `clippy::pedantic` to make linting stricter.
2. **Breaking:** make `draw_image` and `draw_sub_image` borrow instead of owning the image.