### PR TITLE
Add Point::new and SIze::new

### DIFF
--- a/src/graphics/point.rs
+++ b/src/graphics/point.rs
@@ -22,6 +22,14 @@ impl Point {
     /// The coordinate of the top-left corner on the screen.
     pub const MIN: Point = Point { x: 0, y: 0 };
 
+    #[must_use]
+    pub fn new<I: Into<i32>>(x: I, y: I) -> Self {
+        Self {
+            x: x.into(),
+            y: y.into(),
+        }
+    }
+
     /// Set x and y to their absolute (non-negative) value.
     #[must_use]
     pub fn abs(self) -> Self {

--- a/src/graphics/size.rs
+++ b/src/graphics/size.rs
@@ -25,6 +25,14 @@ impl Size {
         height: HEIGHT,
     };
 
+    #[must_use]
+    pub fn new<I: Into<i32>>(width: I, height: I) -> Self {
+        Self {
+            width:  width.into(),
+            height: height.into(),
+        }
+    }
+
     /// Set both width and height to their absolute (non-negative) value.
     #[must_use]
     pub fn abs(self) -> Self {


### PR DESCRIPTION
Using constructors instead of constructing the object directly make cargo fmt to not insert new lines and so the result looks more compact in some situations.