### PR TITLE
Owned versions for Font, Image, and Canvas

### DIFF
--- a/examples/image/firefly.toml
+++ b/examples/image/firefly.toml
@@ -2,7 +2,7 @@ author_id = "demo"
 app_id = "rust-image"
 author_name = "Demo"
 app_name = "Image Demo (Rust)"
-compile_args = ["--features", "std,alloc"]
+compile_args = ["--features", "alloc,talc"]
 
 [files]
 img = { path = "image.png" }

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -8,8 +8,9 @@
 
 #![allow(static_mut_refs)]
 #![no_main]
+#![no_std]
+use core::cell::OnceCell;
 use firefly_rust as ff;
-use std::cell::OnceCell;
 
 static mut IMAGE: OnceCell<ff::ImageBuf> = OnceCell::new();
 

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -11,13 +11,13 @@
 use firefly_rust as ff;
 use std::cell::OnceCell;
 
-static mut IMAGE: OnceCell<ff::FileBuf> = OnceCell::new();
+static mut IMAGE: OnceCell<ff::ImageBuf> = OnceCell::new();
 
 #[unsafe(no_mangle)]
 extern "C" fn boot() {
     let file = ff::load_file_buf("img").unwrap();
     unsafe {
-        IMAGE.set(file).ok().unwrap();
+        IMAGE.set(file.into()).ok().unwrap();
     }
 }
 
@@ -25,6 +25,5 @@ extern "C" fn boot() {
 extern "C" fn update() {
     ff::clear_screen(ff::Color::White);
     let image = unsafe { IMAGE.get().unwrap() };
-    let image: ff::Image = (image).into();
-    ff::draw_image(&image, ff::Point { x: 60, y: 60 });
+    ff::draw_image(image, ff::Point { x: 60, y: 60 });
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -47,12 +47,6 @@ impl FileBuf {
         &self.raw
     }
 
-    /// Interpret the file as a font.
-    #[must_use]
-    pub fn as_font(&'_ self) -> Font<'_> {
-        Font { raw: &self.raw }
-    }
-
     /// Interpret the file as an image.
     #[must_use]
     pub fn as_image(&'_ self) -> Image<'_> {
@@ -127,18 +121,6 @@ impl<'a> File<'a> {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         self.raw
-    }
-
-    /// Interpret the file as a font.
-    #[must_use]
-    pub const fn as_font(&'_ self) -> Font<'_> {
-        Font { raw: self.raw }
-    }
-
-    /// Interpret the file as an image.
-    #[must_use]
-    pub const fn as_image(&'_ self) -> Image<'_> {
-        Image { raw: self.raw }
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -181,9 +181,19 @@ pub fn remove_file(name: &str) {
 mod bindings {
     #[link(wasm_import_module = "fs")]
     unsafe extern "C" {
-        pub(crate) fn get_file_size(path_ptr: u32, path_len: u32) -> u32;
-        pub(crate) fn load_file(path_ptr: u32, path_len: u32, buf_ptr: u32, buf_len: u32) -> u32;
-        pub(crate) fn dump_file(path_ptr: u32, path_len: u32, buf_ptr: u32, buf_len: u32) -> u32;
-        pub(crate) fn remove_file(path_ptr: u32, path_len: u32);
+        pub(crate) unsafe fn get_file_size(path_ptr: u32, path_len: u32) -> u32;
+        pub(crate) unsafe fn load_file(
+            path_ptr: u32,
+            path_len: u32,
+            buf_ptr: u32,
+            buf_len: u32,
+        ) -> u32;
+        pub(crate) unsafe fn dump_file(
+            path_ptr: u32,
+            path_len: u32,
+            buf_ptr: u32,
+            buf_len: u32,
+        ) -> u32;
+        pub(crate) unsafe fn remove_file(path_ptr: u32, path_len: u32);
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
+use alloc::vec;
 
 /// Like [File] but owns the buffer.
 ///

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,16 +1,12 @@
 //! Access file system: the game ROM files and the data dir.
 
-use crate::graphics::*;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use alloc::vec;
 
 /// Like [File] but owns the buffer.
 ///
-/// Returned by [`rom::load_buf`] and [`data::load_buf`]. Requires a global allocator.
-/// For a file of statically-known size, you might want to use [`rom::load`]
-/// and [`data::load`] instead.
+/// Returned by [`load_file_buf`]. Requires a global allocator.
+/// For a file of statically-known size, you might want to use [`load_file`] instead.
 #[cfg(feature = "alloc")]
 pub struct FileBuf {
     pub(crate) raw: Box<[u8]>,
@@ -34,29 +30,6 @@ impl FileBuf {
     pub unsafe fn from_bytes(b: Box<[u8]>) -> Self {
         Self { raw: b }
     }
-
-    /// Access the raw data in the file.
-    #[must_use]
-    pub fn data(&self) -> &[u8] {
-        &self.raw
-    }
-
-    /// Alias for [`FileBuf::data`].
-    #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.raw
-    }
-
-    /// Interpret the file as an image.
-    #[must_use]
-    pub fn as_image(&'_ self) -> Image<'_> {
-        Image { raw: &self.raw }
-    }
-
-    #[must_use]
-    pub fn into_vec(self) -> alloc::vec::Vec<u8> {
-        self.raw.into_vec()
-    }
 }
 
 #[cfg(feature = "alloc")]
@@ -69,7 +42,14 @@ impl From<FileBuf> for Box<[u8]> {
 #[cfg(feature = "alloc")]
 impl From<FileBuf> for alloc::vec::Vec<u8> {
     fn from(value: FileBuf) -> Self {
-        value.into_vec()
+        value.raw.into_vec()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<&'a FileBuf> for &'a [u8] {
+    fn from(value: &'a FileBuf) -> Self {
+        &value.raw
     }
 }
 
@@ -78,7 +58,7 @@ impl TryFrom<FileBuf> for alloc::string::String {
     type Error = alloc::string::FromUtf8Error;
 
     fn try_from(value: FileBuf) -> Result<Self, Self::Error> {
-        let v = value.into_vec();
+        let v = value.raw.into_vec();
         alloc::string::String::from_utf8(v)
     }
 }
@@ -89,11 +69,11 @@ impl TryFrom<FileBuf> for alloc::string::String {
 /// of the right size. If the file size is deterimed dynamically,
 /// you might want to use [`rom::load_buf`] and [`data::load_buf`] instead
 /// (which will take care of the dynamic allocation).
-pub struct File<'a> {
+pub struct FileRef<'a> {
     pub(crate) raw: &'a [u8],
 }
 
-impl<'a> File<'a> {
+impl<'a> FileRef<'a> {
     /// Construct [`File`] from raw bytes.
     ///
     /// The main purpose of this function is to support convering [`File`]
@@ -138,7 +118,7 @@ pub fn get_file_size(name: &str) -> usize {
 ///
 /// If the file size is not known in advance (and so the buffer has to be allocated
 /// dynamically), consider using [`load_file_buf`] instead.
-pub fn load_file<'a>(name: &str, buf: &'a mut [u8]) -> File<'a> {
+pub fn load_file<'a>(name: &str, buf: &'a mut [u8]) -> FileRef<'a> {
     let path_ptr = name.as_ptr();
     let buf_ptr = buf.as_mut_ptr();
     unsafe {
@@ -149,7 +129,7 @@ pub fn load_file<'a>(name: &str, buf: &'a mut [u8]) -> File<'a> {
             buf.len() as u32,
         );
     }
-    File { raw: buf }
+    FileRef { raw: buf }
 }
 
 /// Read the whole file with the given name.

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,5 +1,6 @@
 //! Access file system: the game ROM files and the data dir.
 
+use crate::*;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
@@ -31,6 +32,21 @@ impl FileBuf {
     #[must_use]
     pub unsafe fn from_bytes(b: Box<[u8]>) -> Self {
         Self { raw: b }
+    }
+
+    #[must_use]
+    pub fn into_font(self) -> FontBuf {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_image(self) -> ImageBuf {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_bytes(self) -> Box<[u8]> {
+        self.into()
     }
 }
 
@@ -93,16 +109,25 @@ impl<'a> FileRef<'a> {
         Self { raw: b }
     }
 
-    /// Access the raw data in the file.
     #[must_use]
-    pub const fn data(&self) -> &[u8] {
-        self.raw
+    pub fn into_font(self) -> FontRef<'a> {
+        self.into()
     }
 
-    /// Alias for [`File::data`].
     #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
-        self.raw
+    pub fn into_image(self) -> ImageRef<'a> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_bytes(self) -> &'a [u8] {
+        self.into()
+    }
+}
+
+impl<'a> From<FileRef<'a>> for &'a [u8] {
+    fn from(value: FileRef<'a>) -> Self {
+        value.raw
     }
 }
 

--- a/src/graphics/bindings.rs
+++ b/src/graphics/bindings.rs
@@ -1,9 +1,9 @@
 #[link(wasm_import_module = "graphics")]
 unsafe extern "C" {
-    pub(crate) fn clear_screen(color: i32);
-    pub(crate) fn set_color(index: i32, r: i32, g: i32, b: i32);
-    pub(crate) fn draw_point(x: i32, y: i32, color: i32);
-    pub(crate) fn draw_line(
+    pub(crate) unsafe fn clear_screen(color: i32);
+    pub(crate) unsafe fn set_color(index: i32, r: i32, g: i32, b: i32);
+    pub(crate) unsafe fn draw_point(x: i32, y: i32, color: i32);
+    pub(crate) unsafe fn draw_line(
         p1_x: i32,
         p1_y: i32,
         p2_x: i32,
@@ -11,7 +11,7 @@ unsafe extern "C" {
         color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_rect(
+    pub(crate) unsafe fn draw_rect(
         x: i32,
         y: i32,
         width: i32,
@@ -20,7 +20,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_rounded_rect(
+    pub(crate) unsafe fn draw_rounded_rect(
         x: i32,
         y: i32,
         width: i32,
@@ -31,7 +31,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_circle(
+    pub(crate) unsafe fn draw_circle(
         x: i32,
         y: i32,
         diameter: i32,
@@ -39,7 +39,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_ellipse(
+    pub(crate) unsafe fn draw_ellipse(
         x: i32,
         y: i32,
         width: i32,
@@ -48,7 +48,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_triangle(
+    pub(crate) unsafe fn draw_triangle(
         p1_x: i32,
         p1_y: i32,
         p2_x: i32,
@@ -59,7 +59,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_arc(
+    pub(crate) unsafe fn draw_arc(
         x: i32,
         y: i32,
         diameter: i32,
@@ -69,7 +69,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_sector(
+    pub(crate) unsafe fn draw_sector(
         x: i32,
         y: i32,
         diameter: i32,
@@ -79,7 +79,7 @@ unsafe extern "C" {
         stroke_color: i32,
         stroke_width: i32,
     );
-    pub(crate) fn draw_text(
+    pub(crate) unsafe fn draw_text(
         text_ptr: u32,
         text_len: u32,
         font_ptr: u32,
@@ -88,8 +88,8 @@ unsafe extern "C" {
         y: i32,
         color: i32,
     );
-    pub(crate) fn draw_qr(ptr: u32, len: u32, x: i32, y: i32, black: i32, white: i32);
-    pub(crate) fn draw_sub_image(
+    pub(crate) unsafe fn draw_qr(ptr: u32, len: u32, x: i32, y: i32, black: i32, white: i32);
+    pub(crate) unsafe fn draw_sub_image(
         ptr: u32,
         len: u32,
         x: i32,
@@ -99,7 +99,7 @@ unsafe extern "C" {
         sub_width: i32,
         sub_height: i32,
     );
-    pub(crate) fn draw_image(ptr: u32, len: u32, x: i32, y: i32);
-    pub(crate) fn set_canvas(ptr: u32, len: u32);
-    pub(crate) fn unset_canvas();
+    pub(crate) unsafe fn draw_image(ptr: u32, len: u32, x: i32, y: i32);
+    pub(crate) unsafe fn set_canvas(ptr: u32, len: u32);
+    pub(crate) unsafe fn unset_canvas();
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -102,3 +102,9 @@ const fn prepare_slice(raw: &mut [u8], width: i32) {
     raw[2] = (width >> 8) as u8; // width
     raw[3] = 255; // transparency
 }
+
+impl<T: Canvas> Image for T {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        unsafe { Canvas::as_bytes(self) }
+    }
+}

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -46,6 +46,7 @@ impl CanvasBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Canvas for CanvasBuf {
     unsafe fn as_bytes(&self) -> &[u8] {
         &self.raw

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -4,9 +4,23 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec;
 
-// TODO: add statically-allocated version when prepare_slice can be turned into static fn.
-// It is blocked by this feature going into stable:
-// https://github.com/rust-lang/rust/issues/57349
+// /// Canvas is an [`Image`] that can be drawn upon.
+// #[cfg(feature = "alloc")]
+// pub struct CanvasStatic<const SIZE: usize> {
+//     pub(crate) raw: [u8; SIZE],
+// }
+
+// impl<const SIZE: usize> CanvasStatic<SIZE> {
+//     /// Create new [`CanvasStatic`].
+//     #[must_use]
+//     pub const fn new(width: usize) -> Self {
+//         const HEADER_SIZE: usize = 4;
+//         let mut raw = [0u8; SIZE];
+//         #[expect(clippy::cast_possible_wrap)]
+//         prepare_slice(&mut raw, width as i32);
+//         Self { raw }
+//     }
+// }
 
 /// Canvas is an [`Image`] that can be drawn upon.
 ///
@@ -30,26 +44,20 @@ impl CanvasBuf {
             raw: raw.into_boxed_slice(),
         }
     }
+}
 
-    /// Represent the canvas as an [`Image`].
-    #[must_use]
-    pub const fn as_image(&self) -> Image<'_> {
-        Image { raw: &self.raw }
-    }
-
-    /// Represent the buffered canvas as [`Canvas`].
-    #[must_use]
-    pub const fn as_canvas(&self) -> Canvas<'_> {
-        Canvas { raw: &self.raw }
+impl Canvas for CanvasBuf {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        &self.raw
     }
 }
 
 /// Canvas is an [`Image`] that can be drawn upon.
-pub struct Canvas<'a> {
+pub struct CanvasRef<'a> {
     pub(crate) raw: &'a [u8],
 }
 
-impl<'a> Canvas<'a> {
+impl<'a> CanvasRef<'a> {
     /// Create new empty canvas using the given slice.
     ///
     /// Returns [`None`] if the slice is too small for the given image size.
@@ -68,23 +76,27 @@ impl<'a> Canvas<'a> {
             raw: &raw[..exp_size],
         })
     }
+}
 
-    /// Represent the canvas as an [`Image`].
-    #[must_use]
-    pub const fn as_image(&self) -> Image<'a> {
-        Image { raw: self.raw }
+impl Canvas for CanvasRef<'_> {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        self.raw
     }
 }
 
-#[cfg(feature = "alloc")]
-impl<'a> From<&'a CanvasBuf> for Canvas<'a> {
-    fn from(value: &'a CanvasBuf) -> Self {
-        Self { raw: &value.raw }
-    }
+/// Canvas is an [`Image`] that can be drawn upon.
+pub trait Canvas {
+    /// Get the raw canvas representation.
+    ///
+    /// # Safety
+    ///
+    /// Don't use it. The internal canvas representation might change
+    /// in the future and so should not be relied upon.
+    unsafe fn as_bytes(&self) -> &[u8];
 }
 
 #[expect(clippy::cast_sign_loss)]
-fn prepare_slice(raw: &mut [u8], width: i32) {
+const fn prepare_slice(raw: &mut [u8], width: i32) {
     raw[0] = 0x22; // magic number
     raw[1] = width as u8; // width
     raw[2] = (width >> 8) as u8; // width

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -44,6 +44,11 @@ impl CanvasBuf {
             raw: raw.into_boxed_slice(),
         }
     }
+
+    #[must_use]
+    pub fn into_image(self) -> ImageBuf {
+        self.into()
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -76,6 +81,11 @@ impl<'a> CanvasRef<'a> {
         Some(Self {
             raw: &raw[..exp_size],
         })
+    }
+
+    #[must_use]
+    pub fn into_image(self) -> ImageRef<'a> {
+        self.into()
     }
 }
 

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -34,7 +34,6 @@ impl Font for FontRef<'_> {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<'a> From<FileRef<'a>> for FontRef<'a> {
     fn from(value: FileRef<'a>) -> Self {
         Self { raw: value.raw }

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -6,7 +6,7 @@ use crate::*;
 /// and then cast using [`Into::into`].
 #[cfg(feature = "alloc")]
 pub struct FontBuf {
-    pub(crate) raw: Box<[u8]>,
+    pub(crate) raw: alloc::boxed::Box<[u8]>,
 }
 
 #[cfg(feature = "alloc")]
@@ -35,16 +35,9 @@ impl Font for FontRef<'_> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> From<File<'a>> for FontRef<'a> {
-    fn from(value: File<'a>) -> Self {
+impl<'a> From<FileRef<'a>> for FontRef<'a> {
+    fn from(value: FileRef<'a>) -> Self {
         Self { raw: value.raw }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a> From<&'a FontBuf> for FontRef<'a> {
-    fn from(value: &'a FontBuf) -> Self {
-        Self { raw: &value.raw }
     }
 }
 

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -1,25 +1,75 @@
 use crate::*;
 
-/// A loaded font file.
+/// Owned version of [`Font`].
 ///
 /// Can be loaded as [`FileBuf`] from ROM with [`load_file_buf`]
-/// and then cast using [`FileBuf::as_font`].
-pub struct Font<'a> {
-    pub(crate) raw: &'a [u8],
+/// and then cast using [`Into::into`].
+#[cfg(feature = "alloc")]
+pub struct FontBuf {
+    pub(crate) raw: Box<[u8]>,
 }
 
-impl Font<'_> {
+#[cfg(feature = "alloc")]
+impl Font for FontBuf {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FileBuf> for FontBuf {
+    fn from(value: FileBuf) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
+/// Borrowed version of [`Font`].
+pub struct FontRef<'a> {
+    raw: &'a [u8],
+}
+
+impl Font for FontRef<'_> {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        self.raw
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<File<'a>> for FontRef<'a> {
+    fn from(value: File<'a>) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<&'a FontBuf> for FontRef<'a> {
+    fn from(value: &'a FontBuf) -> Self {
+        Self { raw: &value.raw }
+    }
+}
+
+/// A loaded font file.
+pub trait Font {
+    /// Get the raw font file representation.
+    ///
+    /// # Safety
+    ///
+    /// Don't use it. The internal font representation might change
+    /// in the future and so should not be relied upon.
+    unsafe fn as_bytes(&self) -> &[u8];
+
     /// Check if the font encoding is ASCII.
     #[must_use]
-    pub fn is_ascii(&self) -> bool {
-        self.raw[1] == 0
+    fn is_ascii(&self) -> bool {
+        let raw = unsafe { self.as_bytes() };
+        raw[1] == 0
     }
 
     /// Calculate width (in pixels) of the given ASCII text.
     ///
     /// This function does not account for newlines.
     #[must_use]
-    pub fn line_width_ascii(&self, t: &str) -> u32 {
+    fn line_width_ascii(&self, t: &str) -> u32 {
         t.len() as u32 * u32::from(self.char_width())
     }
 
@@ -27,38 +77,28 @@ impl Font<'_> {
     ///
     /// This function does not account for newlines.
     #[must_use]
-    pub fn line_width_utf8(&self, t: &str) -> u32 {
+    fn line_width_utf8(&self, t: &str) -> u32 {
         t.chars().count() as u32 * u32::from(self.char_width())
     }
 
     /// The width (in pixels) of one glyph bounding box.
     #[must_use]
-    pub fn char_width(&self) -> u8 {
-        self.raw[2]
+    fn char_width(&self) -> u8 {
+        let raw = unsafe { self.as_bytes() };
+        raw[2]
     }
 
     /// The height (in pixels) of one glyph (one line) bounding box.
     #[must_use]
-    pub fn char_height(&self) -> u8 {
-        self.raw[3]
+    fn char_height(&self) -> u8 {
+        let raw = unsafe { self.as_bytes() };
+        raw[3]
     }
 
     /// Offset from the top of the glyph bounding box to the baseline.
     #[must_use]
-    pub fn baseline(&self) -> u8 {
-        self.raw[4]
-    }
-}
-
-impl<'a> From<File<'a>> for Font<'a> {
-    fn from(value: File<'a>) -> Self {
-        Self { raw: value.raw }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a> From<&'a FileBuf> for Font<'a> {
-    fn from(value: &'a FileBuf) -> Self {
-        Self { raw: &value.raw }
+    fn baseline(&self) -> u8 {
+        let raw = unsafe { self.as_bytes() };
+        raw[4]
     }
 }

--- a/src/graphics/funcs.rs
+++ b/src/graphics/funcs.rs
@@ -142,13 +142,14 @@ pub fn draw_sector(p: Point, d: i32, start: Angle, sweep: Angle, s: Style) {
 
 /// Render text using the given font.
 ///
-/// Unlike in the other drawing functions, here [Point] points not to the top-left corner
-/// but to the baseline start position.
-pub fn draw_text(t: &str, f: &Font, p: Point, c: Color) {
+/// Unlike in the other drawing functions, here [`Point`] points not to the top-left
+/// corner but to the baseline start position ([`Font::baseline`]).
+pub fn draw_text<F: Font>(t: &str, f: &F, p: Point, c: Color) {
     let text_ptr = t.as_ptr();
     let text_len = t.len();
-    let font_ptr = f.raw.as_ptr();
-    let font_len = f.raw.len();
+    let font = unsafe { f.as_bytes() };
+    let font_ptr = font.as_ptr();
+    let font_len = font.len();
     unsafe {
         b::draw_text(
             text_ptr as u32,

--- a/src/graphics/funcs.rs
+++ b/src/graphics/funcs.rs
@@ -203,9 +203,10 @@ pub fn draw_sub_image(i: &SubImage, p: Point) {
 }
 
 /// Set canvas to be used for all subsequent drawing operations.
-pub fn set_canvas(c: &Canvas) {
-    let ptr = c.raw.as_ptr();
-    let len = c.raw.len();
+pub fn set_canvas<C: Canvas>(c: &C) {
+    let raw = unsafe { c.as_bytes() };
+    let ptr = raw.as_ptr();
+    let len = raw.len();
     unsafe {
         b::set_canvas(ptr as u32, len as u32);
     }

--- a/src/graphics/funcs.rs
+++ b/src/graphics/funcs.rs
@@ -173,9 +173,10 @@ pub fn draw_qr(t: &str, p: Point, black: Color, white: Color) {
 }
 
 /// Render an image using the given colors.
-pub fn draw_image(i: &Image, p: Point) {
-    let ptr = i.raw.as_ptr();
-    let len = i.raw.len();
+pub fn draw_image<I: Image>(i: &I, p: Point) {
+    let raw = unsafe { i.as_bytes() };
+    let ptr = raw.as_ptr();
+    let len = raw.len();
     unsafe {
         b::draw_image(ptr as u32, len as u32, p.x, p.y);
     }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -1,40 +1,37 @@
 use crate::*;
 
-/// A loaded image file.
+/// Owned version of [`Image`].
 ///
 /// Can be loaded as [`FileBuf`] from ROM with [`load_file_buf`]
+/// and then cast using [`Into::into`].
+#[cfg(feature = "alloc")]
+pub struct ImageBuf {
+    pub(crate) raw: alloc::boxed::Box<[u8]>,
+}
+
+#[cfg(feature = "alloc")]
+impl Image for ImageBuf {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FileBuf> for ImageBuf {
+    fn from(value: FileBuf) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
+/// A loaded image file.
+///
+/// Can be loaded as [`FileRef`] from ROM with [`load_file`]
 /// and then cast using [`Into`].
-pub struct Image<'a> {
-    pub(crate) raw: &'a [u8],
+pub struct ImageRef<'a> {
+    raw: &'a [u8],
 }
 
-impl<'a> From<FileRef<'a>> for Image<'a> {
-    fn from(value: FileRef<'a>) -> Self {
-        Self { raw: value.raw }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a> From<&'a FileBuf> for Image<'a> {
-    fn from(value: &'a FileBuf) -> Self {
-        Self { raw: &value.raw }
-    }
-}
-
-impl<'a> From<Canvas<'a>> for Image<'a> {
-    fn from(value: Canvas<'a>) -> Self {
-        Self { raw: value.raw }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a> From<&'a CanvasBuf> for Image<'a> {
-    fn from(value: &'a CanvasBuf) -> Self {
-        Self { raw: &value.raw }
-    }
-}
-
-impl<'a> Image<'a> {
+impl<'a> ImageRef<'a> {
     /// Reinterpret raw bytes as an image.
     ///
     /// # Safety
@@ -43,45 +40,72 @@ impl<'a> Image<'a> {
     /// Firefly Zero binary image format. In 99% cases, you should not construct
     /// a raw image but instead load it from a [`File`] or generate using [`Canvas`].
     #[must_use]
-    pub const unsafe fn from_bytes(raw: &'a [u8]) -> Self {
+    pub unsafe fn from_bytes(raw: &'a [u8]) -> Self {
         Self { raw }
     }
+}
+
+impl Image for ImageRef<'_> {
+    unsafe fn as_bytes(&self) -> &[u8] {
+        self.raw
+    }
+}
+
+impl<'a> From<FileRef<'a>> for ImageRef<'a> {
+    fn from(value: FileRef<'a>) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
+/// A loaded image file.
+pub trait Image {
+    /// Get the raw image representation.
+    ///
+    /// # Safety
+    ///
+    /// Don't use it. The internal image representation might change
+    /// in the future and so should not be relied upon.
+    unsafe fn as_bytes(&self) -> &[u8];
 
     /// Get a rectangle subregion of the image.
     #[must_use]
-    pub const fn sub(&self, p: Point, s: Size) -> SubImage<'a> {
+    fn sub(&self, p: Point, s: Size) -> SubImage<'_> {
+        let raw = unsafe { self.as_bytes() };
         SubImage {
             point: p,
             size: s,
-            raw: self.raw,
+            raw,
         }
     }
 
     /// The color used for transparency. If no transparency, returns [`Color::None`].
     #[must_use]
-    pub fn transparency(&self) -> Color {
-        Color::from(self.raw[3] + 1)
+    fn transparency(&self) -> Color {
+        let raw = unsafe { self.as_bytes() };
+        Color::from(raw[3] + 1)
     }
 
     /// The number of pixels the image has.
     #[must_use]
-    pub const fn pixels(&self) -> usize {
+    fn pixels(&self) -> usize {
         const HEADER_SIZE: usize = 4;
         const PPB: usize = 2;
-        (self.raw.len() - HEADER_SIZE) * PPB
+        let raw = unsafe { self.as_bytes() };
+        (raw.len() - HEADER_SIZE) * PPB
     }
 
     /// The image width in pixels.
     #[must_use]
-    pub fn width(&self) -> u16 {
-        let big = u16::from(self.raw[1]);
-        let little = u16::from(self.raw[2]);
+    fn width(&self) -> u16 {
+        let raw = unsafe { self.as_bytes() };
+        let big = u16::from(raw[1]);
+        let little = u16::from(raw[2]);
         big | (little << 8)
     }
 
     /// The image height in pixels.
     #[must_use]
-    pub fn height(&self) -> u16 {
+    fn height(&self) -> u16 {
         let p = self.pixels();
         let w = usize::from(self.width());
         p.checked_div(w).unwrap_or(0) as u16
@@ -89,7 +113,7 @@ impl<'a> Image<'a> {
 
     /// The image size in pixels.
     #[must_use]
-    pub fn size(&self) -> Size {
+    fn size(&self) -> Size {
         Size {
             width: i32::from(self.width()),
             height: i32::from(self.height()),

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -8,8 +8,8 @@ pub struct Image<'a> {
     pub(crate) raw: &'a [u8],
 }
 
-impl<'a> From<File<'a>> for Image<'a> {
-    fn from(value: File<'a>) -> Self {
+impl<'a> From<FileRef<'a>> for Image<'a> {
+    fn from(value: FileRef<'a>) -> Self {
         Self { raw: value.raw }
     }
 }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -23,6 +23,13 @@ impl From<FileBuf> for ImageBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl From<CanvasBuf> for ImageBuf {
+    fn from(value: CanvasBuf) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
 /// A loaded image file.
 ///
 /// Can be loaded as [`FileRef`] from ROM with [`load_file`]
@@ -53,6 +60,12 @@ impl Image for ImageRef<'_> {
 
 impl<'a> From<FileRef<'a>> for ImageRef<'a> {
     fn from(value: FileRef<'a>) -> Self {
+        Self { raw: value.raw }
+    }
+}
+
+impl<'a> From<CanvasRef<'a>> for ImageRef<'a> {
+    fn from(value: CanvasRef<'a>) -> Self {
         Self { raw: value.raw }
     }
 }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -1,7 +1,5 @@
 //! Draw shapes, images, and text on the screen.
 
-#![deny(missing_docs)]
-
 mod angle;
 mod bindings;
 mod canvas;

--- a/src/input.rs
+++ b/src/input.rs
@@ -376,7 +376,7 @@ fn has_bit_set(val: u32, bit: usize) -> bool {
 mod bindings {
     #[link(wasm_import_module = "input")]
     unsafe extern "C" {
-        pub(crate) fn read_pad(peer: u32) -> u32;
-        pub(crate) fn read_buttons(peer: u32) -> u32;
+        pub(crate) unsafe fn read_pad(peer: u32) -> u32;
+        pub(crate) unsafe fn read_buttons(peer: u32) -> u32;
     }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -31,8 +31,8 @@ pub fn open_menu() {
 mod bindings {
     #[link(wasm_import_module = "menu")]
     unsafe extern "C" {
-        pub(crate) fn add_menu_item(index: u32, text_ptr: u32, text_len: u32);
-        pub(crate) fn remove_menu_item(index: u32);
-        pub(crate) fn open_menu();
+        pub(crate) unsafe fn add_menu_item(index: u32, text_ptr: u32, text_len: u32);
+        pub(crate) unsafe fn remove_menu_item(index: u32);
+        pub(crate) unsafe fn open_menu();
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -279,9 +279,9 @@ pub fn load_stash_buf<const N: usize>(peer: Peer) -> Option<[u8; N]> {
 mod bindings {
     #[link(wasm_import_module = "net")]
     unsafe extern "C" {
-        pub(crate) fn get_me() -> u32;
-        pub(crate) fn get_peers() -> u32;
-        pub(crate) fn save_stash(peer: u32, ptr: u32, len: u32);
-        pub(crate) fn load_stash(peer: u32, ptr: u32, len: u32) -> u32;
+        pub(crate) unsafe fn get_me() -> u32;
+        pub(crate) unsafe fn get_peers() -> u32;
+        pub(crate) unsafe fn save_stash(peer: u32, ptr: u32, len: u32);
+        pub(crate) unsafe fn load_stash(peer: u32, ptr: u32, len: u32) -> u32;
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -65,7 +65,7 @@ pub fn add_score(p: Peer, b: Board, v: i16) -> i16 {
 mod bindings {
     #[link(wasm_import_module = "stats")]
     unsafe extern "C" {
-        pub(crate) fn add_progress(peer_id: u32, badge_id: u32, val: i32) -> u32;
-        pub(crate) fn add_score(peer_id: u32, board_id: u32, new_score: i32) -> i32;
+        pub(crate) unsafe fn add_progress(peer_id: u32, badge_id: u32, val: i32) -> u32;
+        pub(crate) unsafe fn add_score(peer_id: u32, board_id: u32, new_score: i32) -> i32;
     }
 }


### PR DESCRIPTION
1. Rename Font into `FontRef`
2. Move font methods into `Font` trait
3. Add owned version of font: `FontBuf`
4. Implement `Font` for `FontBuf`
5. Do the same for `Canvas` and `Image`
6. Also implement `Image` for `Canvas`
